### PR TITLE
Added more fields to data stored in queue + Updated queue test cases

### DIFF
--- a/server/controllers/home.js
+++ b/server/controllers/home.js
@@ -51,26 +51,3 @@ exports.post_unfreeze_queue = function (req, res) {
     queueFrozen = false;
     res.redirect("/");
 }
-
-exports.post_add_question = function (req, res) {
-    // fields we get from client
-    const question = req.body.question;
-    const location = req.body.location;
-    const topic = req.body.topic;
-
-    // TODO: error handling
-    if (!question || !location || !topic) {
-        respond_error(req, res, "Invalid/missing parameters in request", 400);
-        return;
-    }
-
-    // add qn to the queue
-    const studentID = req.user.account.user_id;
-    const andrewID = req.user.andrewID;
-    const entryTime = moment.tz(new Date(), "America/New_York").toDate();
-    ohq.enqueue(studentID, andrewID, question, location, topic, entryTime);
-    const position = ohq.getPosition()
-
-    // add qn to the database
-    
-}

--- a/server/controllers/queue.js
+++ b/server/controllers/queue.js
@@ -355,6 +355,14 @@ class OHQueue {
         });
     }
 
+    getData(studentID) {
+        var node = this.queue.find(x => x.id == studentID);
+        if (node == null) return StudentStatus.ERROR;
+        
+        assert(node.data != null);
+        return node.data;
+    }
+
     /** If found, returns the status of the student with the given id; else returns error */
     getStatus(studentID) {
         var node = this.queue.find(x => x.id == studentID);

--- a/server/tests/queue.test.js
+++ b/server/tests/queue.test.js
@@ -1,8 +1,17 @@
 // Testing code for our queue
 const queue = require('../controllers/queue');
+const moment = require("moment-timezone");
 
 const OHQueue = queue.OHQueue;
 const StudentStatus = queue.StudentStatus;
+
+function testData (data, andrewID, question, location, topic, entryTime) {
+    expect(data.andrewID).toBe(andrewID);
+    expect(data.question).toBe(question);
+    expect(data.location).toBe(location);
+    expect(data.topic).toBe(topic);
+    expect(data.entryTime).toBe(entryTime);
+}
 
 describe('Queue tests', () => {
     test('Creation makes empty queue', () => {
@@ -11,30 +20,35 @@ describe('Queue tests', () => {
         expect(queue.isEmpty()).toBe(true);
     });
 
-    test('Enqueue adds student to be waiting on the queue', () => {
+    test('Enqueue adds student with appropriate fields set on the queue', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
+        
         expect(queue.size()).toBe(1);
         expect(queue.getPosition("student1")).toBe(0);
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        const data = queue.getData("student1");
+        testData(data, "stud1", "qn1", "loc1", "top1", entryTime);
     });
 
     test('Enqueue adds students in FIFO order', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getPosition("student1")).toBe(0);
 
-        queue.enqueue("student2");
+        queue.enqueue("student2", "stud2", "qn2", "loc2", "top2", entryTime);
         expect(queue.size()).toBe(2);
         expect(queue.getPosition("student1")).toBe(0);
         expect(queue.getPosition("student2")).toBe(1);
 
-        queue.enqueue("student3");
+        queue.enqueue("student3", "stud3", "qn3", "loc3", "top3", entryTime);
         expect(queue.size()).toBe(3);
         expect(queue.getPosition("student1")).toBe(0);
         expect(queue.getPosition("student2")).toBe(1);
@@ -46,7 +60,8 @@ describe('Queue tests', () => {
         expect(queue.size()).toBe(0);
         expect(queue.getPosition("student1")).toBe(-1);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getPosition("student1")).toBe(0);
         expect(queue.getPosition("student2")).toBe(-1);
@@ -57,7 +72,8 @@ describe('Queue tests', () => {
         expect(queue.size()).toBe(0);
         expect(queue.getStatus("student1")).toBe(StudentStatus.ERROR);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
         expect(queue.getStatus("student2")).toBe(StudentStatus.ERROR);
@@ -67,117 +83,156 @@ describe('Queue tests', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getPosition("student1")).toBe(0);
 
-        queue.remove("student1");
+        const student1Data = queue.remove("student1");
+        testData(student1Data, "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student2");
+        queue.enqueue("student2", "stud2", "qn2", "loc2", "top2", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getPosition("student2")).toBe(0);
 
-        queue.enqueue("student3");
+        queue.enqueue("student3", "stud3", "qn3", "loc3", "top3", entryTime);
         expect(queue.size()).toBe(2);
         expect(queue.getPosition("student2")).toBe(0);
         expect(queue.getPosition("student3")).toBe(1);
 
-        queue.enqueue("student4");
+        queue.enqueue("student4", "stud4", "qn4", "loc4", "top4", entryTime);
         expect(queue.size()).toBe(3);
         expect(queue.getPosition("student2")).toBe(0);
         expect(queue.getPosition("student3")).toBe(1);
         expect(queue.getPosition("student4")).toBe(2);
 
-        queue.remove("student3");
+        const student3Data = queue.remove("student3");
+        testData(student3Data, "stud3", "qn3", "loc3", "top3", entryTime);
         expect(queue.size()).toBe(2);
         expect(queue.getPosition("student2")).toBe(0);
         expect(queue.getPosition("student4")).toBe(1);
 
-        queue.remove("student4");
+        const student4Data = queue.remove("student4");
+        testData(student4Data, "stud4", "qn4", "loc4", "top4", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getPosition("student2")).toBe(0);
 
-        queue.remove("student2");
+        const student2Data = queue.remove("student2");
+        testData(student2Data, "stud2", "qn2", "loc2", "top2", entryTime);
         expect(queue.size()).toBe(0);
     });
-
+    
     test('Can help/unhelp someone on the queue', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
 
-        queue.help("student1");
+        const helpTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.help("student1", "ta1", helpTime);
         expect(queue.getStatus("student1")).toBe(StudentStatus.BEING_HELPED);
+        const student1Data = queue.getData("student1");
+        expect(student1Data.taID).toBe("ta1");
+        expect(student1Data.helpTime).toBe(helpTime);
+        expect(student1Data.isFrozen).toBe(false);
 
         queue.unhelp("student1");
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        expect(student1Data.taID).toBe(null);
+        expect(student1Data.helpTime).toBe(null);
+        expect(student1Data.isFrozen).toBe(false);
     });
-
+    
     test('Can freeze/unfreeze someone on the queue', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        const student1Data = queue.getData("student1");
+        expect(student1Data.isFrozen).toBe(false);
 
         queue.freeze("student1");
         expect(queue.getStatus("student1")).toBe(StudentStatus.FROZEN);
+        expect(student1Data.isFrozen).toBe(true);
 
         queue.unfreeze("student1");
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        expect(student1Data.isFrozen).toBe(false);
     });
-
+    
     test('Can set/unset fix question for someone on the queue', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
         expect(queue.size()).toBe(1);
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        const student1Data = queue.getData("student1");
+        expect(student1Data.isFrozen).toBe(false);
 
         queue.setFixQuestion("student1");
         expect(queue.getStatus("student1")).toBe(StudentStatus.FIXING_QUESTION);
+        expect(student1Data.isFrozen).toBe(true);
+        expect(student1Data.numAskedToFix).toBe(1);
 
         queue.unsetFixQuestion("student1");
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        expect(student1Data.isFrozen).toBe(false);
+        expect(student1Data.numAskedToFix).toBe(1);
     });
-
+    
     test('Can set/unset cooldown violation for someone on the queue', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
+        const student1Data = queue.getData("student1");
         expect(queue.size()).toBe(1);
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        expect(student1Data.isFrozen).toBe(false);
 
         queue.setCooldownViolation("student1");
         expect(queue.getStatus("student1")).toBe(StudentStatus.COOLDOWN_VIOLATION);
+        expect(student1Data.isFrozen).toBe(true);
 
         queue.unsetCooldownViolation("student1");
         expect(queue.getStatus("student1")).toBe(StudentStatus.WAITING);
+        expect(student1Data.isFrozen).toBe(false);
     });
-
+    
     test('Removing will shift order bypassing frozen students', () => {
         const queue = new OHQueue();
         expect(queue.size()).toBe(0);
 
-        queue.enqueue("student1");
-        queue.enqueue("student2");
-        queue.enqueue("student3");
-        queue.enqueue("student4");
-        queue.enqueue("student5");
+        const entryTime = moment.tz(new Date(), "America/New_York").toDate();
+        queue.enqueue("student1", "stud1", "qn1", "loc1", "top1", entryTime);
+        queue.enqueue("student2", "stud2", "qn2", "loc2", "top2", entryTime);
+        queue.enqueue("student3", "stud3", "qn3", "loc3", "top3", entryTime);
+        queue.enqueue("student4", "stud4", "qn4", "loc4", "top4", entryTime);
+        queue.enqueue("student5", "stud5", "qn5", "loc5", "top5", entryTime);
+        const student1Data = queue.getData("student1");
+        const student2Data = queue.getData("student2");
+        const student3Data = queue.getData("student3");
+        const student4Data = queue.getData("student4");
+        const student5Data = queue.getData("student5");        
         expect(queue.size()).toBe(5);
 
         queue.freeze("student2");
         expect(queue.getStatus("student2")).toBe(StudentStatus.FROZEN);
+        expect(student2Data.isFrozen).toBe(true);
 
         queue.setFixQuestion("student4");
         expect(queue.getStatus("student4")).toBe(StudentStatus.FIXING_QUESTION);
+        expect(student4Data.isFrozen).toBe(true);
 
         queue.remove("student1");
         expect(queue.size()).toBe(4);
@@ -188,6 +243,7 @@ describe('Queue tests', () => {
 
         queue.unfreeze("student2");
         expect(queue.getStatus("student2")).toBe(StudentStatus.WAITING);
+        expect(student2Data.isFrozen).toBe(false);
 
         queue.remove("student3");
         expect(queue.size()).toBe(3);
@@ -195,11 +251,11 @@ describe('Queue tests', () => {
         expect(queue.getPosition("student5")).toBe(1);
         expect(queue.getPosition("student4")).toBe(2);
 
-        queue.enqueue("student6");
+        queue.enqueue("student6", "stud6", "qn6", "loc6", "top6", entryTime);
         queue.setCooldownViolation("student6");
         expect(queue.size()).toBe(4);
         
-        queue.enqueue("student7");
+        queue.enqueue("student7", "stud7", "qn7", "loc7", "top7", entryTime);
         expect(queue.size()).toBe(5);
 
         queue.remove("student2");
@@ -209,4 +265,5 @@ describe('Queue tests', () => {
         expect(queue.getPosition("student4")).toBe(2);
         expect(queue.getPosition("student6")).toBe(3);
     });
+    
 });


### PR DESCRIPTION
Fixes #80
**Key changes**
The data stored in a node of the queue is now
```
{
      id: string,
      andrewID: string,
      status: StudentStatus,
      question: string,
      location: string,
      topic: string,
      entryTime: Moment object,
      taID: int,
      helpTime: Moment object,
      isFrozen: bool,
      numAskedToFix: int
}
```

The `remove` function now returns the node data, so the data can be written back to the database.