### PR TITLE
Fixed bug with creating users across semesters

### DIFF
--- a/server/models/semester_user.js
+++ b/server/models/semester_user.js
@@ -23,7 +23,6 @@ module.exports = (sequelize, DataTypes) => {
   Semester_User.init({
     user_id:{
       type: DataTypes.INTEGER,
-      unique: true
     },
     sem_id:{
       type: DataTypes.STRING(3),


### PR DESCRIPTION
closes #184 

updated the database columns and changed the semester_user model to not have user_id unique anymore and made it have a composite primary key of sem_id and user_id

now you can create TAs for multiple semesters and log in correctly 