### PR TITLE
Fix pagination with unique keys

### DIFF
--- a/client/src/components/metrics/AdminMetrics.tsx
+++ b/client/src/components/metrics/AdminMetrics.tsx
@@ -103,7 +103,7 @@ export default function AdminMetrics() {
                       .slice(studentPage * rowsPerStudentPage, studentPage * rowsPerStudentPage + rowsPerStudentPage)
                       .map((row) => {
                         return (
-                          <TableRow hover role="checkbox" tabIndex={-1} key={row.andrewId}>
+                          <TableRow hover role="checkbox" tabIndex={-1} key={row.student_andrew}>
                             {studentCols.map((column) => {
                               const value = row[column.id];
                               return (
@@ -149,7 +149,7 @@ export default function AdminMetrics() {
                       .slice(taPage * rowsPerTAPage, taPage * rowsPerTAPage + rowsPerTAPage)
                       .map((row) => {
                         return (
-                          <TableRow hover role="checkbox" tabIndex={-1} key={row.andrewId}>
+                          <TableRow hover role="checkbox" tabIndex={-1} key={row.ta_andrew}>
                             {taCols.map((column) => {
                               const value = row[column.id];
                               return (

--- a/client/src/components/metrics/PersonalStats.tsx
+++ b/client/src/components/metrics/PersonalStats.tsx
@@ -107,9 +107,9 @@ export default function PersonalStats() {
                 <TableBody>
                   {helpedStudents
                       .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                      .map((row) => {
+                      .map((row, i) => {
                         return (
-                          <TableRow hover role="checkbox" tabIndex={-1} key={row.andrewId}>
+                          <TableRow hover role="checkbox" tabIndex={-1} key={row.andrewId + i}>
                             {columns.map((column) => {
                               const value = row[column.id];
                               return (


### PR DESCRIPTION
Issue on Metrics page with Personal Statistics pagination for student questions not working.  Fixed by making the keys of the table rows unique